### PR TITLE
Fixed the PATH environment variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN PERL_MM_USE_DEFAULT=1 apt-get update -q \
     && cd /opt/pipeline/validation && perl Makefile.PL \
     && make && make test && make install 
 
+ENV PATH /opt/ngs-tools/bin:$PATH
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
Added "ENV PATH /opt/ngs-tools/bin:$PATH" so the ngs-tools are now accessible.
